### PR TITLE
Added links to the new labels for Nautilus and Totem

### DIFF
--- a/Oranchelo/apps/scalable/org.gnome.Nautilus.svg
+++ b/Oranchelo/apps/scalable/org.gnome.Nautilus.svg
@@ -1,0 +1,1 @@
+file-manager.svg

--- a/Oranchelo/apps/scalable/org.gnome.Totem.svg
+++ b/Oranchelo/apps/scalable/org.gnome.Totem.svg
@@ -1,0 +1,1 @@
+totem.svg


### PR DESCRIPTION
With Gnome 3.22, the icon names for Nautilus and Totem are respectively `org.gnome.Nautilus` and `org.gnome.Totem`. I added the links.