### PR TITLE
Allow setting install prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-INSTALLDIR=$(DESTDIR)/usr/share/icons
+PREFIX?=/usr
+INSTALLDIR=$(DESTDIR)$(PREFIX)/share/icons
 THEMES_BASE_NAME=Oranchelo
 
 install:


### PR DESCRIPTION
Instead of hard-coding `/usr` as the install location, allow the user to override using the PREFIX variable.